### PR TITLE
[Python] Specify dependency with `install_requires`

### DIFF
--- a/ElectricCommander-Python-Module/setup.py
+++ b/ElectricCommander-Python-Module/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 setup(name='ec',
       version='0.1.2',
-      requires=['httplib2'],
+      install_requires=['httplib2'],
       author='Sandeep Tamhankar',
       author_email='sandman@electric-cloud.com',
       url='http://www.electric-cloud.com',


### PR DESCRIPTION
This way tooling will automatically install it as a dependency.

See: http://setuptools.readthedocs.io/en/latest/setuptools.html